### PR TITLE
Update data to CLDR v45

### DIFF
--- a/langcodes/data/language-subtag-registry.txt
+++ b/langcodes/data/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2021-08-06
+File-Date: 2024-05-16
 %%
 Type: language
 Subtag: aa
@@ -882,6 +882,7 @@ Type: language
 Subtag: sa
 Description: Sanskrit
 Added: 2005-10-16
+Scope: macrolanguage
 %%
 Type: language
 Subtag: sc
@@ -2143,12 +2144,21 @@ Type: language
 Subtag: ajp
 Description: South Levantine Arabic
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: apc
 Macrolanguage: ar
+%%
+Type: language
+Subtag: ajs
+Description: Algerian Jewish Sign Language
+Added: 2022-02-25
 %%
 Type: language
 Subtag: ajt
 Description: Judeo-Tunisian Arabic
 Added: 2009-07-29
+Deprecated: 2022-02-25
+Preferred-Value: aeb
 Macrolanguage: jrb
 %%
 Type: language
@@ -2783,7 +2793,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: apc
-Description: North Levantine Arabic
+Description: Levantine Arabic
 Added: 2009-07-29
 Macrolanguage: ar
 %%
@@ -5772,6 +5782,11 @@ Added: 2009-07-29
 Deprecated: 2020-03-28
 %%
 Type: language
+Subtag: bpc
+Description: Mbuk
+Added: 2022-02-25
+%%
+Type: language
 Subtag: bpd
 Description: Banda-Banda
 Added: 2009-07-29
@@ -6016,6 +6031,7 @@ Added: 2005-10-16
 %%
 Type: language
 Subtag: brb
+Description: Brao
 Description: Lave
 Added: 2009-07-29
 %%
@@ -8013,6 +8029,12 @@ Description: Lowland Oaxaca Chontal
 Added: 2009-07-29
 %%
 Type: language
+Subtag: cls
+Description: Classical Sanskrit
+Added: 2024-03-04
+Macrolanguage: sa
+%%
+Type: language
 Subtag: clt
 Description: Lautu Chin
 Added: 2012-08-12
@@ -8153,6 +8175,11 @@ Description: Northern Ping Chinese
 Description: Northern Pinghua
 Added: 2020-03-28
 Macrolanguage: zh
+%%
+Type: language
+Subtag: cnq
+Description: Chung
+Added: 2022-02-25
 %%
 Type: language
 Subtag: cnr
@@ -8757,6 +8784,8 @@ Subtag: cug
 Description: Chungmboko
 Description: Cung
 Added: 2009-07-29
+Deprecated: 2022-02-25
+Comments: see bpc, cnq
 %%
 Type: language
 Subtag: cuh
@@ -8888,6 +8917,11 @@ Type: language
 Subtag: cwt
 Description: Kuwaataay
 Added: 2009-07-29
+%%
+Type: language
+Subtag: cxh
+Description: Cha'ari
+Added: 2023-03-17
 %%
 Type: language
 Subtag: cya
@@ -9368,6 +9402,7 @@ Macrolanguage: doi
 %%
 Type: language
 Subtag: dgr
+Description: Tlicho
 Description: Dogrib
 Description: Tłı̨chǫ
 Added: 2005-10-16
@@ -10156,6 +10191,11 @@ Description: Disa
 Added: 2009-07-29
 %%
 Type: language
+Subtag: dsk
+Description: Dokshi
+Added: 2023-03-17
+%%
+Type: language
 Subtag: dsl
 Description: Danish Sign Language
 Added: 2009-07-29
@@ -10174,6 +10214,11 @@ Type: language
 Subtag: dsq
 Description: Tadaksahak
 Added: 2009-07-29
+%%
+Type: language
+Subtag: dsz
+Description: Mardin Sign Language
+Added: 2022-02-25
 %%
 Type: language
 Subtag: dta
@@ -10478,6 +10523,11 @@ Description: Jola-Fonyi
 Added: 2009-07-29
 %%
 Type: language
+Subtag: dyr
+Description: Dyarim
+Added: 2023-03-17
+%%
+Type: language
 Subtag: dyu
 Description: Dyula
 Added: 2005-10-16
@@ -10497,7 +10547,6 @@ Type: language
 Subtag: dzd
 Description: Daza
 Added: 2009-07-29
-Deprecated: 2015-02-12
 %%
 Type: language
 Subtag: dze
@@ -10600,6 +10649,11 @@ Type: language
 Subtag: egl
 Description: Emilian
 Added: 2009-07-29
+%%
+Type: language
+Subtag: egm
+Description: Benamanga
+Added: 2022-02-25
 %%
 Type: language
 Subtag: ego
@@ -10913,7 +10967,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: env
-Description: Enwan (Edu State)
+Description: Enwan (Edo State)
 Added: 2009-07-29
 %%
 Type: language
@@ -11114,6 +11168,11 @@ Type: language
 Subtag: etz
 Description: Semimi
 Added: 2009-07-29
+%%
+Type: language
+Subtag: eud
+Description: Eudeve
+Added: 2023-03-17
 %%
 Type: language
 Subtag: euq
@@ -11329,6 +11388,7 @@ Added: 2009-07-29
 Type: language
 Subtag: fit
 Description: Tornedalen Finnish
+Description: Meänkieli
 Added: 2009-07-29
 %%
 Type: language
@@ -12836,6 +12896,11 @@ Type: language
 Subtag: gou
 Description: Gavar
 Added: 2009-07-29
+%%
+Type: language
+Subtag: gov
+Description: Goo
+Added: 2022-02-25
 %%
 Type: language
 Subtag: gow
@@ -14769,6 +14834,11 @@ Added: 2009-07-29
 Macrolanguage: iu
 %%
 Type: language
+Subtag: ikh
+Description: Ikhin-Arokho
+Added: 2023-03-17
+%%
+Type: language
 Subtag: iki
 Description: Iko
 Added: 2009-07-29
@@ -14939,6 +15009,11 @@ Type: language
 Subtag: ims
 Description: Marsian
 Added: 2009-07-29
+%%
+Type: language
+Subtag: imt
+Description: Imotong
+Added: 2022-02-25
 %%
 Type: language
 Subtag: imy
@@ -15181,6 +15256,11 @@ Description: Isu (Menchum Division)
 Added: 2009-07-29
 %%
 Type: language
+Subtag: isv
+Description: Interslavic
+Added: 2024-05-15
+%%
+Type: language
 Subtag: itb
 Description: Binongan Itneg
 Added: 2009-07-29
@@ -15337,6 +15417,11 @@ Description: Izi-Ezaa-Ikwo-Mgbo
 Added: 2009-07-29
 Deprecated: 2013-09-10
 Comments: see eza, gmz, iqw, izz
+%%
+Type: language
+Subtag: izm
+Description: Kizamani
+Added: 2023-03-17
 %%
 Type: language
 Subtag: izr
@@ -16881,6 +16966,8 @@ Type: language
 Subtag: kgm
 Description: Karipúna
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: plu
 %%
 Type: language
 Subtag: kgn
@@ -18298,7 +18385,7 @@ Scope: collection
 %%
 Type: language
 Subtag: krp
-Description: Korop
+Description: Durop
 Added: 2009-07-29
 %%
 Type: language
@@ -18351,6 +18438,8 @@ Type: language
 Subtag: ksa
 Description: Shuwa-Zamani
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Comments: see izm, rsw
 %%
 Type: language
 Subtag: ksb
@@ -19435,7 +19524,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: lag
-Description: Langi
+Description: Rangi
 Added: 2009-07-29
 %%
 Type: language
@@ -19458,6 +19547,8 @@ Type: language
 Subtag: lak
 Description: Laka (Nigeria)
 Added: 2009-07-29
+Deprecated: 2022-02-25
+Preferred-Value: ksp
 %%
 Type: language
 Subtag: lal
@@ -19953,6 +20044,11 @@ Description: Opuuo
 Added: 2009-07-29
 %%
 Type: language
+Subtag: lgo
+Description: Lango (South Sudan)
+Added: 2022-02-25
+%%
+Type: language
 Subtag: lgq
 Description: Logba
 Added: 2009-07-29
@@ -19961,6 +20057,12 @@ Type: language
 Subtag: lgr
 Description: Lengo
 Added: 2009-07-29
+%%
+Type: language
+Subtag: lgs
+Description: Guinea-Bissau Sign Language
+Description: Língua Gestual Guineense
+Added: 2023-03-17
 %%
 Type: language
 Subtag: lgt
@@ -20552,6 +20654,8 @@ Type: language
 Subtag: lno
 Description: Lango (South Sudan)
 Added: 2009-07-29
+Deprecated: 2022-02-25
+Comments: see imt, lgo, lqr, oie
 %%
 Type: language
 Subtag: lns
@@ -20605,6 +20709,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: loh
+Description: Laarim
 Description: Narim
 Added: 2009-07-29
 %%
@@ -20724,6 +20829,11 @@ Description: Lopit
 Added: 2009-07-29
 %%
 Type: language
+Subtag: lqr
+Description: Logir
+Added: 2022-02-25
+%%
+Type: language
 Subtag: lra
 Description: Rara Bakati'
 Added: 2009-07-29
@@ -20809,6 +20919,12 @@ Description: Langue des Signes Burundaise
 Added: 2021-02-20
 %%
 Type: language
+Subtag: lsc
+Description: Albarradas Sign Language
+Description: Lengua de señas Albarradas
+Added: 2022-02-25
+%%
+Type: language
 Subtag: lsd
 Description: Lishana Deni
 Added: 2009-07-29
@@ -20881,6 +20997,13 @@ Type: language
 Subtag: lsv
 Description: Sivia Sign Language
 Added: 2019-04-16
+%%
+Type: language
+Subtag: lsw
+Description: Seychelles Sign Language
+Description: Lalang Siny Seselwa
+Description: Langue des Signes Seychelloise
+Added: 2022-02-25
 %%
 Type: language
 Subtag: lsy
@@ -21059,6 +21182,11 @@ Type: language
 Subtag: lvk
 Description: Lavukaleve
 Added: 2009-07-29
+%%
+Type: language
+Subtag: lvl
+Description: Lwel
+Added: 2023-03-17
 %%
 Type: language
 Subtag: lvs
@@ -26120,6 +26248,8 @@ Type: language
 Subtag: nom
 Description: Nocamán
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: cbr
 %%
 Type: language
 Subtag: non
@@ -26310,6 +26440,7 @@ Type: language
 Subtag: nrf
 Description: Jèrriais
 Description: Guernésiais
+Description: Sercquiais
 Added: 2015-02-12
 %%
 Type: language
@@ -26779,6 +26910,11 @@ Description: Nawaru
 Added: 2009-07-29
 %%
 Type: language
+Subtag: nww
+Description: Ndwewe
+Added: 2022-02-25
+%%
+Type: language
 Subtag: nwx
 Description: Middle Newar
 Added: 2009-07-29
@@ -27014,6 +27150,11 @@ Description: Zeme Naga
 Added: 2009-07-29
 %%
 Type: language
+Subtag: nzr
+Description: Dir-Nyamzak-Mbarimi
+Added: 2023-03-17
+%%
+Type: language
 Subtag: nzs
 Description: New Zealand Sign Language
 Added: 2009-07-29
@@ -27199,6 +27340,11 @@ Type: language
 Subtag: oia
 Description: Oirata
 Added: 2009-07-29
+%%
+Type: language
+Subtag: oie
+Description: Okolie
+Added: 2022-02-25
 %%
 Type: language
 Subtag: oin
@@ -28472,6 +28618,11 @@ Added: 2005-10-16
 Scope: collection
 %%
 Type: language
+Subtag: phj
+Description: Pahari
+Added: 2022-02-25
+%%
+Type: language
 Subtag: phk
 Description: Phake
 Added: 2009-07-29
@@ -28572,6 +28723,7 @@ Type: language
 Subtag: pii
 Description: Pini
 Added: 2009-07-29
+Deprecated: 2022-02-25
 %%
 Type: language
 Subtag: pij
@@ -28761,6 +28913,8 @@ Type: language
 Subtag: plj
 Description: Polci
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Comments: see nzr, pze, uly, zlu
 %%
 Type: language
 Subtag: plk
@@ -28886,6 +29040,8 @@ Type: language
 Subtag: pmk
 Description: Pamlico
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: crr
 %%
 Type: language
 Subtag: pml
@@ -29362,6 +29518,8 @@ Type: language
 Subtag: prp
 Description: Parsi
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: gu
 %%
 Type: language
 Subtag: prq
@@ -29419,6 +29577,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: psc
+Description: Iranian Sign Language
 Description: Persian Sign Language
 Added: 2009-07-29
 %%
@@ -29772,7 +29931,18 @@ Description: Pyen
 Added: 2009-07-29
 %%
 Type: language
+Subtag: pze
+Description: Pesse
+Added: 2023-03-17
+%%
+Type: language
+Subtag: pzh
+Description: Pazeh
+Added: 2022-02-25
+%%
+Type: language
 Subtag: pzn
+Description: Jejara Naga
 Description: Para Naga
 Added: 2009-07-29
 %%
@@ -30394,6 +30564,11 @@ Description: Riang (India)
 Added: 2009-07-29
 %%
 Type: language
+Subtag: rib
+Description: Bribri Sign Language
+Added: 2022-02-25
+%%
+Type: language
 Subtag: rie
 Description: Rien
 Added: 2009-07-29
@@ -30627,6 +30802,11 @@ Added: 2009-07-29
 Deprecated: 2016-05-30
 %%
 Type: language
+Subtag: rnb
+Description: Brunca Sign Language
+Added: 2022-02-25
+%%
+Type: language
 Subtag: rnd
 Description: Ruund
 Added: 2009-07-29
@@ -30749,6 +30929,11 @@ Description: Ririo
 Added: 2009-07-29
 %%
 Type: language
+Subtag: rrm
+Description: Moriori
+Added: 2024-03-04
+%%
+Type: language
 Subtag: rro
 Description: Waima
 Added: 2009-07-29
@@ -30770,6 +30955,12 @@ Added: 2009-07-29
 Deprecated: 2017-02-23
 %%
 Type: language
+Subtag: rsk
+Description: Ruthenian
+Description: Rusnak
+Added: 2022-02-25
+%%
+Type: language
 Subtag: rsl
 Description: Russian Sign Language
 Added: 2009-07-29
@@ -30778,6 +30969,16 @@ Type: language
 Subtag: rsm
 Description: Miriwoong Sign Language
 Added: 2016-05-30
+%%
+Type: language
+Subtag: rsn
+Description: Rwandan Sign Language
+Added: 2022-02-25
+%%
+Type: language
+Subtag: rsw
+Description: Rishiwa
+Added: 2023-03-17
 %%
 Type: language
 Subtag: rtc
@@ -32216,6 +32417,7 @@ Type: language
 Subtag: slq
 Description: Salchuq
 Added: 2009-07-29
+Deprecated: 2023-03-17
 %%
 Type: language
 Subtag: slr
@@ -32276,6 +32478,8 @@ Type: language
 Subtag: smd
 Description: Sama
 Added: 2009-07-29
+Deprecated: 2022-02-25
+Preferred-Value: kmb
 %%
 Type: language
 Subtag: smf
@@ -32382,6 +32586,8 @@ Type: language
 Subtag: snb
 Description: Sebuyau
 Added: 2009-07-29
+Deprecated: 2022-02-25
+Preferred-Value: iba
 %%
 Type: language
 Subtag: snc
@@ -33569,6 +33775,8 @@ Type: language
 Subtag: szd
 Description: Seru
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: umi
 %%
 Type: language
 Subtag: sze
@@ -34949,6 +35157,8 @@ Type: language
 Subtag: tmk
 Description: Northwestern Tamang
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: tdg
 %%
 Type: language
 Subtag: tml
@@ -35199,6 +35409,11 @@ Description: Tojolabal
 Added: 2009-07-29
 %%
 Type: language
+Subtag: tok
+Description: Toki Pona
+Added: 2022-02-25
+%%
+Type: language
 Subtag: tol
 Description: Tolowa
 Added: 2009-07-29
@@ -35360,6 +35575,8 @@ Type: language
 Subtag: tpw
 Description: Tupí
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: tpn
 %%
 Type: language
 Subtag: tpx
@@ -35541,6 +35758,8 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: trv
+Description: Sediq
+Description: Seediq
 Description: Taroko
 Added: 2009-07-29
 %%
@@ -35951,6 +36170,11 @@ Type: language
 Subtag: tve
 Description: Te'un
 Added: 2009-07-29
+%%
+Type: language
+Subtag: tvi
+Description: Tulai
+Added: 2023-03-17
 %%
 Type: language
 Subtag: tvk
@@ -36432,6 +36656,11 @@ Description: Ughele
 Added: 2009-07-29
 %%
 Type: language
+Subtag: ugh
+Description: Kubachi
+Added: 2022-02-25
+%%
+Type: language
 Subtag: ugn
 Description: Ugandan Sign Language
 Added: 2009-07-29
@@ -36599,6 +36828,11 @@ Description: Ulwa
 Added: 2010-03-11
 %%
 Type: language
+Subtag: uly
+Description: Buli
+Added: 2023-03-17
+%%
+Type: language
 Subtag: uma
 Description: Umatilla
 Added: 2009-07-29
@@ -36740,6 +36974,11 @@ Description: Uokha
 Added: 2009-07-29
 Deprecated: 2015-02-12
 Preferred-Value: ema
+%%
+Type: language
+Subtag: uon
+Description: Kulon
+Added: 2022-02-25
 %%
 Type: language
 Subtag: upi
@@ -36944,6 +37183,8 @@ Type: language
 Subtag: uun
 Description: Kulon-Pazeh
 Added: 2009-07-29
+Deprecated: 2022-02-25
+Comments: see pzh, uon
 %%
 Type: language
 Subtag: uur
@@ -37181,6 +37422,11 @@ Type: language
 Subtag: viv
 Description: Iduna
 Added: 2009-07-29
+%%
+Type: language
+Subtag: vjk
+Description: Bajjika
+Added: 2023-03-17
 %%
 Type: language
 Subtag: vka
@@ -37430,6 +37676,12 @@ Type: language
 Subtag: vsl
 Description: Venezuelan Sign Language
 Added: 2009-07-29
+%%
+Type: language
+Subtag: vsn
+Description: Vedic Sanskrit
+Added: 2024-03-04
+Macrolanguage: sa
 %%
 Type: language
 Subtag: vsv
@@ -37712,6 +37964,11 @@ Type: language
 Subtag: wdk
 Description: Wadikali
 Added: 2013-09-10
+%%
+Type: language
+Subtag: wdt
+Description: Wendat
+Added: 2022-02-25
 %%
 Type: language
 Subtag: wdu
@@ -38176,7 +38433,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: wnb
-Description: Wanambre
+Description: Mokati
 Added: 2009-07-29
 %%
 Type: language
@@ -38348,6 +38605,7 @@ Type: language
 Subtag: wrd
 Description: Warduji
 Added: 2009-07-29
+Deprecated: 2022-02-25
 %%
 Type: language
 Subtag: wrg
@@ -38476,6 +38734,11 @@ Type: language
 Subtag: wsv
 Description: Wotapuri-Katarqalai
 Added: 2009-07-29
+%%
+Type: language
+Subtag: wtb
+Description: Matambwe
+Added: 2023-03-17
 %%
 Type: language
 Subtag: wtf
@@ -38613,6 +38876,8 @@ Type: language
 Subtag: wya
 Description: Wyandot
 Added: 2009-07-29
+Deprecated: 2022-02-25
+Comments: see wdt, wyn
 %%
 Type: language
 Subtag: wyb
@@ -38628,6 +38893,11 @@ Type: language
 Subtag: wym
 Description: Wymysorys
 Added: 2009-07-29
+%%
+Type: language
+Subtag: wyn
+Description: Wyandot
+Added: 2022-02-25
 %%
 Type: language
 Subtag: wyr
@@ -38936,6 +39206,11 @@ Description: Kwandu
 Added: 2017-02-23
 %%
 Type: language
+Subtag: xdq
+Description: Kaitag
+Added: 2022-02-25
+%%
+Type: language
 Subtag: xdy
 Description: Malayic Dayak
 Added: 2009-07-29
@@ -39079,6 +39354,11 @@ Added: 2009-07-29
 Macrolanguage: lah
 %%
 Type: language
+Subtag: xhm
+Description: Middle Khmer (1400 to 1850 CE)
+Added: 2022-02-25
+%%
+Type: language
 Subtag: xhr
 Description: Hernican
 Added: 2009-07-29
@@ -39215,6 +39495,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: xkk
+Description: Kachok
 Description: Kaco'
 Added: 2009-07-29
 %%
@@ -39469,6 +39750,7 @@ Macrolanguage: mg
 %%
 Type: language
 Subtag: xmx
+Description: Salawati
 Description: Maden
 Added: 2009-07-29
 %%
@@ -39925,6 +40207,8 @@ Type: language
 Subtag: xss
 Description: Assan
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: zko
 %%
 Type: language
 Subtag: xsu
@@ -40508,6 +40792,11 @@ Description: Chepya
 Added: 2009-07-29
 %%
 Type: language
+Subtag: ycr
+Description: Yilan Creole
+Added: 2023-03-17
+%%
+Type: language
 Subtag: yda
 Description: Yanda
 Added: 2013-09-10
@@ -40785,6 +41074,11 @@ Type: language
 Subtag: ykg
 Description: Northern Yukaghir
 Added: 2009-07-29
+%%
+Type: language
+Subtag: ykh
+Description: Khamnigan Mongol
+Added: 2023-03-17
 %%
 Type: language
 Subtag: yki
@@ -41728,6 +42022,12 @@ Added: 2009-07-29
 Macrolanguage: zap
 %%
 Type: language
+Subtag: zcd
+Description: Las Delicias Zapotec
+Added: 2022-02-25
+Macrolanguage: zap
+%%
+Type: language
 Subtag: zch
 Description: Central Hongshuihe Zhuang
 Added: 2009-07-29
@@ -41753,6 +42053,11 @@ Subtag: zeh
 Description: Eastern Hongshuihe Zhuang
 Added: 2009-07-29
 Macrolanguage: za
+%%
+Type: language
+Subtag: zem
+Description: Zeem
+Added: 2023-03-17
 %%
 Type: language
 Subtag: zen
@@ -41881,6 +42186,8 @@ Type: language
 Subtag: zkb
 Description: Koibal
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Preferred-Value: kjh
 %%
 Type: language
 Subtag: zkd
@@ -41982,6 +42289,11 @@ Subtag: zls
 Description: South Slavic languages
 Added: 2009-07-29
 Scope: collection
+%%
+Type: language
+Subtag: zlu
+Description: Zul
+Added: 2023-03-17
 %%
 Type: language
 Subtag: zlw
@@ -42488,6 +42800,8 @@ Type: language
 Subtag: zua
 Description: Zeem
 Added: 2009-07-29
+Deprecated: 2023-03-17
+Comments: see cxh, dsk, dyr, tvi, zem
 %%
 Type: language
 Subtag: zuh
@@ -42695,13 +43009,21 @@ Type: extlang
 Subtag: ajp
 Description: South Levantine Arabic
 Added: 2009-07-29
+Deprecated: 2023-03-17
 Preferred-Value: ajp
 Prefix: ar
 Macrolanguage: ar
 %%
 Type: extlang
+Subtag: ajs
+Description: Algerian Jewish Sign Language
+Added: 2022-02-25
+Preferred-Value: ajs
+Prefix: sgn
+%%
+Type: extlang
 Subtag: apc
-Description: North Levantine Arabic
+Description: Levantine Arabic
 Added: 2009-07-29
 Preferred-Value: apc
 Prefix: ar
@@ -43101,6 +43423,13 @@ Subtag: dsl
 Description: Danish Sign Language
 Added: 2009-07-29
 Preferred-Value: dsl
+Prefix: sgn
+%%
+Type: extlang
+Subtag: dsz
+Description: Mardin Sign Language
+Added: 2022-02-25
+Preferred-Value: dsz
 Prefix: sgn
 %%
 Type: extlang
@@ -43515,6 +43844,14 @@ Prefix: ms
 Macrolanguage: ms
 %%
 Type: extlang
+Subtag: lgs
+Description: Guinea-Bissau Sign Language
+Description: Língua Gestual Guineense
+Added: 2023-03-17
+Preferred-Value: lgs
+Prefix: sgn
+%%
+Type: extlang
 Subtag: liw
 Description: Col
 Added: 2009-07-29
@@ -43535,6 +43872,14 @@ Description: Burundian Sign Language
 Description: Langue des Signes Burundaise
 Added: 2021-02-20
 Preferred-Value: lsb
+Prefix: sgn
+%%
+Type: extlang
+Subtag: lsc
+Description: Albarradas Sign Language
+Description: Lengua de señas Albarradas
+Added: 2022-02-25
+Preferred-Value: lsc
 Prefix: sgn
 %%
 Type: extlang
@@ -43586,6 +43931,15 @@ Subtag: lsv
 Description: Sivia Sign Language
 Added: 2019-04-16
 Preferred-Value: lsv
+Prefix: sgn
+%%
+Type: extlang
+Subtag: lsw
+Description: Seychelles Sign Language
+Description: Lalang Siny Seselwa
+Description: Langue des Signes Seychelloise
+Added: 2022-02-25
+Preferred-Value: lsw
 Prefix: sgn
 %%
 Type: extlang
@@ -43880,6 +44234,7 @@ Prefix: sgn
 %%
 Type: extlang
 Subtag: psc
+Description: Iranian Sign Language
 Description: Persian Sign Language
 Added: 2009-07-29
 Preferred-Value: psc
@@ -43944,10 +44299,24 @@ Preferred-Value: pys
 Prefix: sgn
 %%
 Type: extlang
+Subtag: rib
+Description: Bribri Sign Language
+Added: 2022-02-25
+Preferred-Value: rib
+Prefix: sgn
+%%
+Type: extlang
 Subtag: rms
 Description: Romanian Sign Language
 Added: 2009-07-29
 Preferred-Value: rms
+Prefix: sgn
+%%
+Type: extlang
+Subtag: rnb
+Description: Brunca Sign Language
+Added: 2022-02-25
+Preferred-Value: rnb
 Prefix: sgn
 %%
 Type: extlang
@@ -43970,6 +44339,13 @@ Subtag: rsm
 Description: Miriwoong Sign Language
 Added: 2016-05-30
 Preferred-Value: rsm
+Prefix: sgn
+%%
+Type: extlang
+Subtag: rsn
+Description: Rwandan Sign Language
+Added: 2022-02-25
+Preferred-Value: rsn
 Prefix: sgn
 %%
 Type: extlang
@@ -44528,6 +44904,11 @@ Description: Cherokee
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Chis
+Description: Chisoi
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Chrs
 Description: Chorasmian
 Added: 2019-09-11
@@ -44623,6 +45004,11 @@ Description: Ge'ez
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Gara
+Description: Garay
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Geok
 Description: Khutsuri (Asomtavruli and Nuskhuri)
 Added: 2005-10-16
@@ -44666,6 +45052,11 @@ Type: script
 Subtag: Gujr
 Description: Gujarati
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Gukh
+Description: Gurung Khema
+Added: 2023-10-16
 %%
 Type: script
 Subtag: Guru
@@ -44793,6 +45184,11 @@ Description: Katakana
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Kawi
+Description: Kawi
+Added: 2021-12-24
+%%
+Type: script
 Subtag: Khar
 Description: Kharoshthi
 Added: 2005-10-16
@@ -44831,6 +45227,11 @@ Type: script
 Subtag: Kpel
 Description: Kpelle
 Added: 2010-04-10
+%%
+Type: script
+Subtag: Krai
+Description: Kirat Rai
+Added: 2023-10-16
 %%
 Type: script
 Subtag: Kthi
@@ -45012,6 +45413,11 @@ Description: Burmese
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Nagm
+Description: Nag Mundari
+Added: 2021-12-24
+%%
+Type: script
 Subtag: Nand
 Description: Nandinagari
 Added: 2018-10-28
@@ -45073,6 +45479,11 @@ Description: Ol Cemet'
 Description: Ol
 Description: Santali
 Added: 2006-07-21
+%%
+Type: script
+Subtag: Onao
+Description: Ol Onal
+Added: 2023-10-16
 %%
 Type: script
 Subtag: Orkh
@@ -45254,6 +45665,11 @@ Description: Siddhamātṛkā
 Added: 2013-12-02
 %%
 Type: script
+Subtag: Sidt
+Description: Sidetic
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Sind
 Description: Khudawadi
 Description: Sindhi
@@ -45288,6 +45704,11 @@ Type: script
 Subtag: Sund
 Description: Sundanese
 Added: 2006-07-21
+%%
+Type: script
+Subtag: Sunu
+Description: Sunuwar
+Added: 2021-12-24
 %%
 Type: script
 Subtag: Sylo
@@ -45352,6 +45773,11 @@ Description: Tai Viet
 Added: 2007-12-05
 %%
 Type: script
+Subtag: Tayo
+Description: Tai Yo
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Telu
 Description: Telugu
 Added: 2005-10-16
@@ -45400,9 +45826,24 @@ Description: Tangsa
 Added: 2021-03-05
 %%
 Type: script
+Subtag: Todr
+Description: Todhri
+Added: 2023-10-16
+%%
+Type: script
+Subtag: Tols
+Description: Tolong Siki
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Toto
 Description: Toto
 Added: 2020-05-12
+%%
+Type: script
+Subtag: Tutg
+Description: Tulu-Tigalari
+Added: 2023-10-16
 %%
 Type: script
 Subtag: Ugar
@@ -45777,6 +46218,11 @@ Type: region
 Subtag: CP
 Description: Clipperton Island
 Added: 2009-07-29
+%%
+Type: region
+Subtag: CQ
+Description: Sark
+Added: 2023-02-07
 %%
 Type: region
 Subtag: CR
@@ -46736,6 +47182,7 @@ Preferred-Value: TL
 %%
 Type: region
 Subtag: TR
+Description: Türkiye
 Description: Turkey
 Added: 2005-10-16
 %%
@@ -47136,6 +47583,13 @@ Comments: Aluku dialect of the "Busi Nenge Tongo" English-based Creole
   continuum in Eastern Suriname and Western French Guiana
 %%
 Type: variant
+Subtag: anpezo
+Description: Anpezo standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in Anpezo
+%%
+Type: variant
 Subtag: ao1990
 Description: Portuguese Language Orthographic Agreement of 1990 (Acordo
   Ortográfico da Língua Portuguesa de 1990)
@@ -47239,6 +47693,23 @@ Added: 2010-07-28
 Prefix: sa
 %%
 Type: variant
+Subtag: bciav
+Description: BCI Blissymbolics AV
+Added: 2023-05-11
+Prefix: zbl
+Comments: Name given to a subset of the variety of Blissymbolics curated
+  by Blissymbolics Communication International, as represented by
+  entries in the BCI Authorized Vocabulary
+%%
+Type: variant
+Subtag: bcizbl
+Description: BCI Blissymbolics
+Added: 2023-05-11
+Prefix: zbl
+Comments: Name given to the variety of Blissymbolics curated by
+  Blissymbolics Communication International
+%%
+Type: variant
 Subtag: biscayan
 Description: Biscayan dialect of Basque
 Added: 2010-04-13
@@ -47252,6 +47723,15 @@ Added: 2007-07-05
 Prefix: sl-rozaj
 Comments: The dialect of San Giorgio/Bila is one of the four major local
   dialects of Resian
+%%
+Type: variant
+Subtag: blasl
+Description: Black American Sign Language dialect
+Added: 2023-07-31
+Prefix: ase
+Prefix: sgn-ase
+Comments: Black American Sign Language (BASL) or Black Sign Variation
+  (BSV) is a dialect of American Sign Language (ASL)
 %%
 Type: variant
 Subtag: bohoric
@@ -47330,6 +47810,22 @@ Added: 2012-02-05
 Prefix: en
 %%
 Type: variant
+Subtag: fascia
+Description: Fascia standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in Fascia which
+  unified the three subvarieties Cazet, Brach and Moenat
+%%
+Type: variant
+Subtag: fodom
+Description: Fodom standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in Livinallongo
+  and Colle Santa Lucia
+%%
+Type: variant
 Subtag: fonipa
 Description: International Phonetic Alphabet
 Added: 2006-12-11
@@ -47368,6 +47864,13 @@ Description: Gascon
 Added: 2018-04-22
 Prefix: oc
 Comments: Occitan variant spoken in Gascony
+%%
+Type: variant
+Subtag: gherd
+Description: Gherdëina standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in Gherdëina
 %%
 Type: variant
 Subtag: grclass
@@ -47532,6 +48035,19 @@ Comments: The dialect of Lipovaz/Lipovec is one of the minor local
   dialects of Resian
 %%
 Type: variant
+Subtag: ltg1929
+Description: The Latgalian language orthography codified in 1929
+Added: 2022-08-05
+Prefix: ltg
+%%
+Type: variant
+Subtag: ltg2007
+Description: The Latgalian language orthography codified in the language
+  law in 2007
+Added: 2022-06-23
+Prefix: ltg
+%%
+Type: variant
 Subtag: luna1918
 Description: Post-1917 Russian orthography
 Added: 2010-10-10
@@ -47656,6 +48172,15 @@ Prefix: la
 Comments: Peano’s Interlingua, created in 1903 by Giuseppe Peano as an
   international auxiliary language
 Added: 2020-03-12
+%%
+Type: variant
+Subtag: pehoeji
+Description: Hokkien Vernacular Romanization System
+Description: Pe̍h-ōe-jī orthography/romanization
+Added: 2024-03-04
+Prefix: nan-Latn
+Comments: Modern Hokkien Vernacular Romanization System, evolved from
+  the New Dictionary in the Amoy by John Van Nest Talmage in 1894
 %%
 Type: variant
 Subtag: petr1708
@@ -47792,6 +48317,16 @@ Added: 2021-07-17
 Prefix: da
 %%
 Type: variant
+Subtag: tailo
+Description: Taiwanese Hokkien Romanization System for Hokkien
+  languages
+Description: Tâi-lô orthography/romanization
+Added: 2024-03-04
+Prefix: nan-Latn
+Comments: Taiwanese Hokkien Romanization System (Tâi-lô) published in
+  2006 by the Taiwan Ministry of Education
+%%
+Type: variant
 Subtag: tarask
 Description: Belarusian in Taraskievica orthography
 Added: 2007-04-27
@@ -47853,6 +48388,15 @@ Added: 2010-07-28
 Prefix: sa
 Comments: The most ancient dialect of Sanskrit used in verse and prose
   composed until about the 4th century B.C.E.
+%%
+Type: variant
+Subtag: valbadia
+Description: Val Badia standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in the Val
+  Badia, unifying the three variants Marô, Mesaval and Badiot spoken
+  in this valley
 %%
 Type: variant
 Subtag: valencia


### PR DESCRIPTION
This simple PR updates the data to the latest version of CLDR v45 (@2024-04-17) here:
[Versions](https://cldr.unicode.org/index/downloads)
[Data](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)

I did check the changes and ran the example, but nothing extensive...
