### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/langcodes/util.py
+++ b/langcodes/util.py
@@ -1,6 +1,6 @@
-from pkg_resources import resource_filename
+from importlib.resources import files
 
-DATA_ROOT = resource_filename('langcodes', 'data')
+DATA_ROOT = files('langcodes').joinpath('data')
 import os
 
 


### PR DESCRIPTION
pkg_resources is deprecated as an API, so let's replace it with importlib.resources. See https://setuptools.pypa.io/en/latest/pkg_resources.html